### PR TITLE
Fix local loki address resolver

### DIFF
--- a/python/example.py
+++ b/python/example.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 
-import socket
+import dns.resolver, socket
 
 def ip_to_loki(ip):
     """
@@ -19,7 +19,8 @@ def resolve_local_address():
     """
     get our .loki address
     """
-    return ip_to_loki(get_lokinet_ip())
+    a = dns.resolver.query('localhost.loki', 'CNAME')
+    return a.rrset.to_text().split(' ')[-1]
 
 
 local_addr = resolve_local_address()


### PR DESCRIPTION
Hi, I noticed the python example outputs the local network interface address instead of the loki address.

This fix makes it output the correct loki address as per the go example.